### PR TITLE
Https support for the load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,8 @@ openssl genrsa 2048 > privatekey.pem
 openssl req -new -key privatekey.pem -out csr.pem
 openssl x509 -req -days 365 -in csr.pem -signkey privatekey.pem -out server.crt
 </pre>
+
+## Obtaining Certificate ARNs
+
+The alb stack requires a certificate ARN as an input. The easiest way to
+obtain one is via the aws cli: `aws acm --list-certificates`

--- a/README.md
+++ b/README.md
@@ -94,3 +94,17 @@ openssl x509 -req -days 365 -in csr.pem -signkey privatekey.pem -out server.crt
 
 The alb stack requires a certificate ARN as an input. The easiest way to
 obtain one is via the aws cli: `aws acm --list-certificates`
+
+## Route 53 Parameters
+
+Use the AWS CLI to find the zone name to form the record set for. This can
+be done via `aws route53 list-hosted-zones'. The name is the last component
+of the Config Id property - for example if Id is /hostedzone/xxx then the 
+zone name is xxx.
+
+To form the domain name parameter, combine the name you are associating with
+the load balancer with the parent name associated with the hosted zone.
+
+For example, in the hosted zone config if the name is `foo.com.` and you
+want to associate `dev` in that domain with the load balancer, then
+for the domain name parameter you would specify `dev.foo.com`. 

--- a/README.md
+++ b/README.md
@@ -78,3 +78,14 @@ the logging driver in the task definition.
 Before you can create the sumo integration piece via sumo lambda function stack,
 you need to create an s3 bucked, zip up the [sumo cloud watch lambda function](https://github.com/SumoLogic/sumologic-aws-lambda/tree/master/cloudwatchlogs),
 and drop it into the S3 bucket. The bucket name and zip file name are referenced as stack parameters.
+
+## Self Signed Certificate
+
+For dev if you can tolerate a self signed certificate, here's how to generate
+one for import into the AWS ACM
+
+<pre>
+openssl genrsa 2048 > privatekey.pem
+openssl req -new -key privatekey.pem -out csr.pem
+openssl x509 -req -days 365 -in csr.pem -signkey privatekey.pem -out server.crt
+</pre>

--- a/alb.yaml
+++ b/alb.yaml
@@ -128,3 +128,9 @@ Outputs:
     Value: !Ref 'ALBListener'
     Export:
       Name: !Sub "${AWS::StackName}-ALBListenerArn"
+
+  ALBDnsName:
+    Description: DNSName associated with the ALB
+    Value: !GetAtt ECSALB.DNSName
+    Export:
+      Name: !Sub "${AWS::StackName}-ALBDnsName"

--- a/alb.yaml
+++ b/alb.yaml
@@ -11,6 +11,9 @@ Parameters:
 
   LoadBalancerName:
     Type: String
+    
+  CertificateArn:
+    Type: String
 
 Resources:
 
@@ -36,8 +39,8 @@ Resources:
         Fn::ImportValue: !Sub "${NetworkStack}-VPCID"
       SecurityGroupIngress:
         IpProtocol: tcp
-        FromPort: 80
-        ToPort: 80
+        FromPort: 443
+        ToPort: 443
         CidrIp: 0.0.0.0/0
 
   InboundRule:
@@ -67,12 +70,14 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::Listener
     DependsOn: ECSALB
     Properties:
+      Certificates:
+      - CertificateArn: !Ref CertificateArn
       DefaultActions:
       - Type: forward
         TargetGroupArn: !Ref 'hcpingTG'
       LoadBalancerArn: !Ref 'ECSALB'
-      Port: '80'
-      Protocol: HTTP
+      Port: '443'
+      Protocol: HTTPS
 
   ECSALBListenerRule1:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule

--- a/alb.yaml
+++ b/alb.yaml
@@ -134,3 +134,9 @@ Outputs:
     Value: !GetAtt ECSALB.DNSName
     Export:
       Name: !Sub "${AWS::StackName}-ALBDnsName"
+
+  HostedZoneId:
+    Description: Hosted zone id associated with the ELB
+    Value: !GetAtt ECSALB.CanonicalHostedZoneID
+    Export:
+      Name: !Sub "${AWS::StackName}-HostedZoneId"

--- a/dns.yaml
+++ b/dns.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Create a record set for a hosted zone to associate an alias with
+  the elb name.
+Parameters:
+  ALBStack:
+    Type: String
+  ZoneName:
+    Type: String
+  DomainName:
+    Type: String
+
+Resources:
+
+  MyRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: !Ref DomainName
+      HostedZoneName: !Ref ZoneName
+      Type: A
+      AliasTarget:
+        DNSName: 
+          Fn::ImportValue: !Sub "${ALBStack}-ALBDnsName" 
+        HostedZoneId: 
+          Fn::ImportValue: !Sub "${ALBStack}-HostedZoneId"
+


### PR DESCRIPTION
This PR brings support for https listeners on the load balancer using a certificate imported into the AWS certificate manager. A route 53 record set can optionally be created to associate an alias with the load balancer.